### PR TITLE
Reactify has been replaced by Babelify for JSX Transform

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -6,7 +6,7 @@ var autoprefixer = require('gulp-autoprefixer');
 var plumber = require('gulp-plumber');
 var zip = require('gulp-zip');
 var browserify = require('browserify');       // Bundles JS
-var reactify = require('reactify');           // Transforms React JSX to JS
+var babelify = require('babelify');           // Transforms React JSX to JS
 var source = require('vinyl-source-stream');
 
 var moduleName = 'getwarm';
@@ -85,7 +85,10 @@ gulp.task('compass', function() {
 ////////////////////////////////////////////////////////////////////////////////
 gulp.task('js', function() {
     browserify('./src/js/main.js')
-    .transform({global:true},reactify)
+    .transform({global:true}, babelify.configure({
+        // tells the Babel parser that the code uses React's JSX.
+        presets: ["react"]
+    }))
     .bundle()
     .pipe(source('bundle.js'))
     .pipe(gulp.dest('./docker/dist/js'))

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -2,7 +2,7 @@
 
 var gulp = require('gulp');
 var browserify = require('browserify');       // Bundles JS
-var reactify = require('reactify');           // Transforms React JSX to JS
+var babelify = require('babelify');           // Transforms React JSX to JS
 var source = require('vinyl-source-stream');
 var browserSync = require('browser-sync');
 var reload = browserSync.reload;
@@ -31,7 +31,10 @@ gulp.task('html', function() {
 ////////////////////////////////////////////////////////////////////////////////
 gulp.task('js-watch', ['clean','compass-watch'], function() {
     browserify(path.app_js)
-    .transform({global:true},reactify)
+    .transform({global:true}, babelify.configure({
+        // tells the Babel parser that the code uses React's JSX.
+        presets: ["react"]
+    }))
     .bundle()
     .pipe(source('bundle.js'))
     .pipe(gulp.dest('./src/js'))

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "warm-react": "git://github.com/maestro-tech/warm.git#dev"
   },
   "devDependencies": {
+    "babel-preset-react": "^6.3.13",
+    "babelify": "^7.2.0",
     "browser-sync": "^1.3.6",
     "del": "^0.1.3",
     "gulp": "^3.8.0",
@@ -37,12 +39,10 @@
     "gulp-size": "^1.1.0",
     "gulp-useref": "^1.0.0",
     "gulp-zip": "^3.0.2",
-    "http-proxy": "^1.3.0",
-    "reactify": "^1.1.1"
+    "http-proxy": "^1.3.0"
   },
   "browserify": {
     "transform": [
-      "reactify",
       "envify"
     ]
   }


### PR DESCRIPTION
Reactify has been replaced by Babelify for JSX Transform. This is **not** a complete overhaul of the build system, so as not to interfere with the current workflow and cause development slowdowns. 
More in-depth changes will be made when the workflow gets cleaner and there is no need to watch `node_modules` anymore. 